### PR TITLE
Addition of Burst Mode for SPI byte transactions

### DIFF
--- a/src/SpiTbPkg.vhd
+++ b/src/SpiTbPkg.vhd
@@ -6,12 +6,14 @@
 --  Contributor(s):
 --     Guy Eschemann   (original Author)
 --     Jacob Albers
+--     fernandoka
 --
 --  Description:
 --      Constant and Transaction Support for OSVVM SPI VC
 --
 --  Revision History:
 --    Date      Version    Description
+--    11/2024   2024.03    Addition of Burst Mode for SPI byte transactions
 --    04/2024   2024.04    Initial version
 --    06/2022   2022.06    Initial version
 --
@@ -79,7 +81,8 @@ package SpiTbPkg is
     ----------------------------------------------------------------------------
     type SpiOptionType is (
         SET_SCLK_PERIOD,
-        SET_SPI_MODE
+        SET_SPI_MODE,
+        SET_SPI_BURST_MODE
     );
 
     ----------------------------------------------------------------------------
@@ -114,6 +117,11 @@ package SpiTbPkg is
         signal OptSpiMode     : in  SpiModeType;
         signal CPOL           : out std_logic;
         signal CPHA           : out std_logic
+    );
+
+    procedure SetSpiBurstMode(
+        signal   TransactionRec  : inout StreamRecType;
+        constant SpiBurstModeEna : boolean
     );
 
     ----------------------------------------------------------------------------
@@ -163,6 +171,19 @@ package body SpiTbPkg is
         CPOL      <= GetCPOL(OptSpiMode);
         CPHA      <= GetCPHA(OptSpiMode);
     end procedure SetSpiParams;
+
+    ----------------------------------------------------------------------------
+    -- SetSpiBurstMode: Sets SPI device byte transaction characteristics
+    ----------------------------------------------------------------------------
+    procedure SetSpiBurstMode(
+        signal   TransactionRec  : inout StreamRecType;
+        constant SpiBurstModeEna : boolean
+    ) is
+    begin
+        SetModelOptions(TransactionRec,
+                        SpiOptionType'pos(SET_SPI_BURST_MODE),
+                        SpiBurstModeEna);
+    end procedure SetSpiBurstMode;
 
     ----------------------------------------------------------------------------
     -- GetCPOL: Helper function for SetSpiMode returns CPOL value

--- a/testbench/TbSpi.vhd
+++ b/testbench/TbSpi.vhd
@@ -81,7 +81,7 @@ begin
     ------------------------------------------------------------
     -- Create Clock
     ------------------------------------------------------------
-    Osvvm.ClockResetPkg.CreateClock(
+    Osvvm.TbUtilPkg.CreateClock(
         Clk    => Clk,
         Period => tperiod_Clk
     );
@@ -89,7 +89,7 @@ begin
     ------------------------------------------------------------
     -- Create Reset
     ------------------------------------------------------------
-    Osvvm.ClockResetPkg.CreateReset(
+    Osvvm.TbUtilPkg.CreateReset(
         Reset       => n_Reset,
         ResetActive => '0',
         Clk         => Clk,

--- a/testbench/TbSpi_BurstSendGet0.vhd
+++ b/testbench/TbSpi_BurstSendGet0.vhd
@@ -1,6 +1,6 @@
 --
---  File Name:         TbSpi_SendGet3.vhd
---  Design Unit Name:  SendGet3
+--  File Name:         TbSpi_BurstSendGet0.vhd
+--  Design Unit Name:  BurstSendGet0
 --
 --  Maintainer:        OSVVM Authors
 --  Contributor(s):
@@ -8,7 +8,7 @@
 --     fernandoka
 --
 --  Description:
---      SPI Mode 3 Test: Controller sends data. Peripheral receives data
+--      SPI Mode 0 Test: Controller sends data. Peripheral receives data
 --      and checks against expected value.
 --
 --  Revision History:
@@ -32,7 +32,7 @@
 --  limitations under the License.
 --
 
-architecture SendGet3 of TestCtrl is
+architecture BurstSendGet0 of TestCtrl is
 
     signal TestDone   : integer_barrier := 1;
     signal TestActive : boolean         := TRUE;
@@ -46,13 +46,13 @@ begin
     ControlProc : process
     begin
         -- Initialization of test
-        SetTestName("TbSpi_SendGet3");
+        SetTestName("TbSpi_BurstSendGet0");
         SetLogEnable(PASSED, TRUE);
         TbID <= GetAlertLogID("TB");
 
         -- Wait for testbench initialization
         wait for 0 ns; wait for 0 ns;
-        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_SendGet3.txt");
+        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_BurstSendGet0.txt");
         SetTranscriptMirror(TRUE) ;
 
         -- Wait for Design Reset
@@ -85,46 +85,45 @@ begin
         WaitForClock(SpiControllerRec, 2);
 
         -- Test Begins
-        SetSpiMode(SpiControllerRec, 3);
+
         --Send sequence 1
-        Send(SpiControllerRec, X"50");
-        Send(SpiControllerRec, X"51");
-        Send(SpiControllerRec, X"52");
-        Send(SpiControllerRec, X"53");
-        Send(SpiControllerRec, X"54");
-        GetTransactionCount(SpiControllerRec, TransactionCount);
-        AffirmIfEqual(SpiControllerID, TransactionCount,
-                      5,
-                      "Transaction Count");
+        SendAsync(SpiControllerRec, X"50");
+        SendAsync(SpiControllerRec, X"51");
+        SendAsync(SpiControllerRec, X"52");
+        SendAsync(SpiControllerRec, X"53");
+        SendAsync(SpiControllerRec, X"54");
 
         --Send sequence 2
-        Send(SpiControllerRec, X"60");
-        Send(SpiControllerRec, X"61");
-        Send(SpiControllerRec, X"62");
-        Send(SpiControllerRec, X"63");
-        Send(SpiControllerRec, X"64");
+        SendAsync(SpiControllerRec, X"60");
+        SendAsync(SpiControllerRec, X"61");
+        SendAsync(SpiControllerRec, X"62");
+        SendAsync(SpiControllerRec, X"63");
+        SendAsync(SpiControllerRec, X"64");
 
         --Send sequence 3
-        Send(SpiControllerRec, X"70");
-        Send(SpiControllerRec, X"71");
-        Send(SpiControllerRec, X"72");
-        Send(SpiControllerRec, X"73");
-        Send(SpiControllerRec, X"74");
+        SendAsync(SpiControllerRec, X"70");
+        SendAsync(SpiControllerRec, X"71");
+        SendAsync(SpiControllerRec, X"72");
+        SendAsync(SpiControllerRec, X"73");
+        SendAsync(SpiControllerRec, X"74");
 
         --Send sequence 4
-        Send(SpiControllerRec, X"80");
-        Send(SpiControllerRec, X"81");
-        Send(SpiControllerRec, X"82");
-        Send(SpiControllerRec, X"83");
-        Send(SpiControllerRec, X"84");
+        SendAsync(SpiControllerRec, X"80");
+        SendAsync(SpiControllerRec, X"81");
+        SendAsync(SpiControllerRec, X"82");
+        SendAsync(SpiControllerRec, X"83");
+        SendAsync(SpiControllerRec, X"84");
 
-        GetTransactionCount(SpiControllerRec, TransactionCount);
+        -- Waits until all bytes has been sent
+				while TransactionCount<20 loop
+	        GetTransactionCount(SpiControllerRec, TransactionCount);
+					wait for 1 us;
+				end loop;			
         AffirmIfEqual(SpiControllerID, TransactionCount,
                       20,
                       "Transaction Count");
 
         -- Test ends
-        TestActive <= FALSE;
         WaitForBarrier(TestDone);
         wait;
     end process SpiControllerTest;
@@ -145,7 +144,7 @@ begin
     WaitForClock(SpiPeripheralRec, 2);
 
     -- Test Begins
-    SetSpiMode(SpiPeripheralRec, 3);
+
     -- Receive sequence 1
     for i in 1 to 5 loop
         case i is
@@ -211,15 +210,16 @@ begin
 
     -- Test Done
     wait for 1 us;
+    TestActive <= FALSE;
     WaitForBarrier(TestDone);
     wait;
     end process SpiPeripheralTest;
-end SendGet3;
+end BurstSendGet0;
 
-configuration TbSpi_SendGet3 of TbSpi is
+configuration TbSpi_BurstSendGet0 of TbSpi is
     for TestHarness
         for TestCtrl_1 : TestCtrl
-            use entity work.TestCtrl(SendGet3);
+            use entity work.TestCtrl(BurstSendGet0);
         end for;
     end for;
-end TbSpi_SendGet3;
+end TbSpi_BurstSendGet0;

--- a/testbench/TbSpi_BurstSendGet2.vhd
+++ b/testbench/TbSpi_BurstSendGet2.vhd
@@ -1,6 +1,6 @@
 --
---  File Name:         TbSpi_SendGet3.vhd
---  Design Unit Name:  SendGet3
+--  File Name:         TbSpi_BurstSendGet2.vhd
+--  Design Unit Name:  BurstSendGet2
 --
 --  Maintainer:        OSVVM Authors
 --  Contributor(s):
@@ -8,7 +8,7 @@
 --     fernandoka
 --
 --  Description:
---      SPI Mode 3 Test: Controller sends data. Peripheral receives data
+--      SPI Mode 2 Test: Controller sends data. Peripheral receives data
 --      and checks against expected value.
 --
 --  Revision History:
@@ -32,7 +32,7 @@
 --  limitations under the License.
 --
 
-architecture SendGet3 of TestCtrl is
+architecture BurstSendGet2 of TestCtrl is
 
     signal TestDone   : integer_barrier := 1;
     signal TestActive : boolean         := TRUE;
@@ -46,13 +46,13 @@ begin
     ControlProc : process
     begin
         -- Initialization of test
-        SetTestName("TbSpi_SendGet3");
+        SetTestName("TbSpi_BurstSendGet2");
         SetLogEnable(PASSED, TRUE);
         TbID <= GetAlertLogID("TB");
 
         -- Wait for testbench initialization
         wait for 0 ns; wait for 0 ns;
-        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_SendGet3.txt");
+        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_BurstSendGet2.txt");
         SetTranscriptMirror(TRUE) ;
 
         -- Wait for Design Reset
@@ -85,46 +85,48 @@ begin
         WaitForClock(SpiControllerRec, 2);
 
         -- Test Begins
-        SetSpiMode(SpiControllerRec, 3);
-        --Send sequence 1
-        Send(SpiControllerRec, X"50");
-        Send(SpiControllerRec, X"51");
-        Send(SpiControllerRec, X"52");
-        Send(SpiControllerRec, X"53");
-        Send(SpiControllerRec, X"54");
-        GetTransactionCount(SpiControllerRec, TransactionCount);
-        AffirmIfEqual(SpiControllerID, TransactionCount,
-                      5,
-                      "Transaction Count");
+        SetSpiMode(SpiControllerRec, 2);
+        SetSpiBurstMode(SpiControllerRec, True);
 
+        --Send sequence 1
+        SendAsync(SpiControllerRec, X"50");
+        SendAsync(SpiControllerRec, X"50");
+        SendAsync(SpiControllerRec, X"51");
+        SendAsync(SpiControllerRec, X"52");
+        SendAsync(SpiControllerRec, X"53");
+        SendAsync(SpiControllerRec, X"54");
+  
         --Send sequence 2
-        Send(SpiControllerRec, X"60");
-        Send(SpiControllerRec, X"61");
-        Send(SpiControllerRec, X"62");
-        Send(SpiControllerRec, X"63");
-        Send(SpiControllerRec, X"64");
+        SendAsync(SpiControllerRec, X"60");
+        SendAsync(SpiControllerRec, X"61");
+        SendAsync(SpiControllerRec, X"62");
+        SendAsync(SpiControllerRec, X"63");
+        SendAsync(SpiControllerRec, X"64");
 
         --Send sequence 3
-        Send(SpiControllerRec, X"70");
-        Send(SpiControllerRec, X"71");
-        Send(SpiControllerRec, X"72");
-        Send(SpiControllerRec, X"73");
-        Send(SpiControllerRec, X"74");
+        SendAsync(SpiControllerRec, X"70");
+        SendAsync(SpiControllerRec, X"71");
+        SendAsync(SpiControllerRec, X"72");
+        SendAsync(SpiControllerRec, X"73");
+        SendAsync(SpiControllerRec, X"74");
 
         --Send sequence 4
-        Send(SpiControllerRec, X"80");
-        Send(SpiControllerRec, X"81");
-        Send(SpiControllerRec, X"82");
-        Send(SpiControllerRec, X"83");
-        Send(SpiControllerRec, X"84");
+        SendAsync(SpiControllerRec, X"80");
+        SendAsync(SpiControllerRec, X"81");
+        SendAsync(SpiControllerRec, X"82");
+        SendAsync(SpiControllerRec, X"83");
+        SendAsync(SpiControllerRec, X"84");
 
-        GetTransactionCount(SpiControllerRec, TransactionCount);
+        -- Waits until all bytes has been sent
+				while TransactionCount<21 loop
+	        GetTransactionCount(SpiControllerRec, TransactionCount);
+					wait for 1 us;
+				end loop;			
         AffirmIfEqual(SpiControllerID, TransactionCount,
-                      20,
+                      21,
                       "Transaction Count");
 
         -- Test ends
-        TestActive <= FALSE;
         WaitForBarrier(TestDone);
         wait;
     end process SpiControllerTest;
@@ -145,15 +147,16 @@ begin
     WaitForClock(SpiPeripheralRec, 2);
 
     -- Test Begins
-    SetSpiMode(SpiPeripheralRec, 3);
+    SetSpiMode(SpiPeripheralRec, 2);
     -- Receive sequence 1
-    for i in 1 to 5 loop
+    for i in 1 to 6 loop
         case i is
-        when 1 =>  Expected := (X"50");
-        when 2 =>  Expected := (X"51");
-        when 3 =>  Expected := (X"52");
-        when 4 =>  Expected := (X"53");
-        when 5 =>  Expected := (X"54");
+        when 1 =>  Expected := (X"B0"); -- First TX invalid after mode change
+        when 2 =>  Expected := (X"50");
+        when 3 =>  Expected := (X"51");
+        when 4 =>  Expected := (X"52");
+        when 5 =>  Expected := (X"53");
+        when 6 =>  Expected := (X"54");
         end case ;
         Get(SpiPeripheralRec, Received);
         AffirmIfEqual(SpiPeripheralID, Received, Expected);
@@ -211,15 +214,16 @@ begin
 
     -- Test Done
     wait for 1 us;
+    TestActive <= FALSE;
     WaitForBarrier(TestDone);
     wait;
     end process SpiPeripheralTest;
-end SendGet3;
+end BurstSendGet2;
 
-configuration TbSpi_SendGet3 of TbSpi is
+configuration TbSpi_BurstSendGet2 of TbSpi is
     for TestHarness
         for TestCtrl_1 : TestCtrl
-            use entity work.TestCtrl(SendGet3);
+            use entity work.TestCtrl(BurstSendGet2);
         end for;
     end for;
-end TbSpi_SendGet3;
+end TbSpi_BurstSendGet2;

--- a/testbench/TbSpi_BurstSendGet3.vhd
+++ b/testbench/TbSpi_BurstSendGet3.vhd
@@ -1,6 +1,6 @@
 --
---  File Name:         TbSpi_SendGet3.vhd
---  Design Unit Name:  SendGet3
+--  File Name:         TbSpi_BurstSendGet3.vhd
+--  Design Unit Name:  BurstSendGet3
 --
 --  Maintainer:        OSVVM Authors
 --  Contributor(s):
@@ -32,7 +32,7 @@
 --  limitations under the License.
 --
 
-architecture SendGet3 of TestCtrl is
+architecture BurstSendGet3 of TestCtrl is
 
     signal TestDone   : integer_barrier := 1;
     signal TestActive : boolean         := TRUE;
@@ -46,13 +46,14 @@ begin
     ControlProc : process
     begin
         -- Initialization of test
-        SetTestName("TbSpi_SendGet3");
+        SetTestName("TbSpi_BurstSendGet3");
         SetLogEnable(PASSED, TRUE);
+        -- SetLogEnable(DEBUG, TRUE);
         TbID <= GetAlertLogID("TB");
 
         -- Wait for testbench initialization
         wait for 0 ns; wait for 0 ns;
-        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_SendGet3.txt");
+        TranscriptOpen(OSVVM_RESULTS_DIR & "TbSpi_BurstSendGet3.txt");
         SetTranscriptMirror(TRUE) ;
 
         -- Wait for Design Reset
@@ -86,45 +87,46 @@ begin
 
         -- Test Begins
         SetSpiMode(SpiControllerRec, 3);
+        SetSpiBurstMode(SpiControllerRec, True);
+
         --Send sequence 1
-        Send(SpiControllerRec, X"50");
-        Send(SpiControllerRec, X"51");
-        Send(SpiControllerRec, X"52");
-        Send(SpiControllerRec, X"53");
-        Send(SpiControllerRec, X"54");
-        GetTransactionCount(SpiControllerRec, TransactionCount);
-        AffirmIfEqual(SpiControllerID, TransactionCount,
-                      5,
-                      "Transaction Count");
+        SendAsync(SpiControllerRec, X"50");
+        SendAsync(SpiControllerRec, X"51");
+        SendAsync(SpiControllerRec, X"52");
+        SendAsync(SpiControllerRec, X"53");
+        SendAsync(SpiControllerRec, X"54");
 
         --Send sequence 2
-        Send(SpiControllerRec, X"60");
-        Send(SpiControllerRec, X"61");
-        Send(SpiControllerRec, X"62");
-        Send(SpiControllerRec, X"63");
-        Send(SpiControllerRec, X"64");
+        SendAsync(SpiControllerRec, X"60");
+        SendAsync(SpiControllerRec, X"61");
+        SendAsync(SpiControllerRec, X"62");
+        SendAsync(SpiControllerRec, X"63");
+        SendAsync(SpiControllerRec, X"64");
 
         --Send sequence 3
-        Send(SpiControllerRec, X"70");
-        Send(SpiControllerRec, X"71");
-        Send(SpiControllerRec, X"72");
-        Send(SpiControllerRec, X"73");
-        Send(SpiControllerRec, X"74");
+        SendAsync(SpiControllerRec, X"70");
+        SendAsync(SpiControllerRec, X"71");
+        SendAsync(SpiControllerRec, X"72");
+        SendAsync(SpiControllerRec, X"73");
+        SendAsync(SpiControllerRec, X"74");
 
         --Send sequence 4
-        Send(SpiControllerRec, X"80");
-        Send(SpiControllerRec, X"81");
-        Send(SpiControllerRec, X"82");
-        Send(SpiControllerRec, X"83");
-        Send(SpiControllerRec, X"84");
+        SendAsync(SpiControllerRec, X"80");
+        SendAsync(SpiControllerRec, X"81");
+        SendAsync(SpiControllerRec, X"82");
+        SendAsync(SpiControllerRec, X"83");
+        SendAsync(SpiControllerRec, X"84");
 
-        GetTransactionCount(SpiControllerRec, TransactionCount);
+        -- Waits until all bytes has been sent
+				while TransactionCount<20 loop
+	        GetTransactionCount(SpiControllerRec, TransactionCount);
+					wait for 1 us;
+				end loop;			
         AffirmIfEqual(SpiControllerID, TransactionCount,
                       20,
                       "Transaction Count");
 
         -- Test ends
-        TestActive <= FALSE;
         WaitForBarrier(TestDone);
         wait;
     end process SpiControllerTest;
@@ -198,28 +200,18 @@ begin
     AffirmIfEqual(SpiPeripheralID, Received, Expected);
     end loop;
 
-    -- Receive sequence 5
-    for i in 1 to 5 loop
-        case i is
-        when 1 =>  Expected := (X"80");
-        when 2 =>  Expected := (X"81");
-        when 3 =>  Expected := (X"82");
-        when 4 =>  Expected := (X"83");
-        when 5 =>  Expected := (X"84");
-        end case ;
-    end loop;
-
     -- Test Done
     wait for 1 us;
+    TestActive <= FALSE;
     WaitForBarrier(TestDone);
     wait;
     end process SpiPeripheralTest;
-end SendGet3;
+end BurstSendGet3;
 
-configuration TbSpi_SendGet3 of TbSpi is
+configuration TbSpi_BurstSendGet3 of TbSpi is
     for TestHarness
         for TestCtrl_1 : TestCtrl
-            use entity work.TestCtrl(SendGet3);
+            use entity work.TestCtrl(BurstSendGet3);
         end for;
     end for;
-end TbSpi_SendGet3;
+end TbSpi_BurstSendGet3;

--- a/testbench/testbench.pro
+++ b/testbench/testbench.pro
@@ -6,12 +6,14 @@
 #  Contributor(s):
 #     Guy Eschemann   (original Author)
 #     Jacob Albers
+#     fernandoka
 #
 #  Description:
 #    Run testbenches for SPI
 #
 #  Revision History:
 #    Date      Version    Description
+#    11/2024   2024.03    Addition of Burst Mode for SPI byte transactions
 #    06/2022   2022.06    Initial version
 #
 #  This file is part of OSVVM.
@@ -37,11 +39,16 @@ analyze  OsvvmTestCommonPkg.vhd
 analyze  TestCtrl_e.vhd
 analyze  TbSpi.vhd
 
-SetSaveWaves
+
 RunTest  TbSpi_SendGet0.vhd
 RunTest  TbSpi_SendGet1.vhd
 RunTest  TbSpi_SendGet2.vhd
 RunTest  TbSpi_SendGet3.vhd
+
+RunTest  TbSpi_BurstSendGet0.vhd
+RunTest  TbSpi_BurstSendGet1.vhd
+RunTest  TbSpi_BurstSendGet2.vhd
+RunTest  TbSpi_BurstSendGet3.vhd
 
 RunTest  TbSpi_CtrlRx0.vhd
 RunTest  TbSpi_CtrlRx1.vhd


### PR DESCRIPTION
With this commit, I added some improvements to support a "Burst" mode to transmit more than one byte in a single SPI transaction. With the modifications I have made in  "SpiPeripheral" model, more than one byte can be received without set CSEN line High for each data byte transmitted (CSEN keeps Low for more than one byte).

I have also modified "SpiController" model and "SpiTbPkg" package, to support "Burst" mode in the controller side as well. This new functionality has been tested, including test cases which enables "Burst" mode ("TbSpi_BurstSendGetx"). All the other test cases keep passing.

The following images show how the waveform varies between "TbSpi_BurstSendGet3" and "TbSpi_SendGet3" test cases.

![TbSpi_SendGet3_wave](https://github.com/user-attachments/assets/78be3b7b-c338-4b74-82fd-2a3756bf8dcf)
*Figure 1 : SPI bus. Waveform obtained in "TbSpi_SendGet3". "Burst" mode disabled*


![TbSpi_BurstSendGet3_wave](https://github.com/user-attachments/assets/9975ea3f-a25a-49b9-80a2-9258f0bce581)
*Figure 2 : SPI bus. Waveform obtained in "TbSpi_BurstSendGet3". "Burst" mode enabled*

Thanks to this improvement, the SPI VCs are able to cover a wider range of real-world applications.
